### PR TITLE
Introduce boolean option for Audio Receive only mode

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -45,6 +45,7 @@
         id<RTCVideoEncoderFactory> encoderFactory = options.videoEncoderFactory;
         NSDictionary *fieldTrials = options.fieldTrials;
         RTCLoggingSeverity loggingSeverity = options.loggingSeverity;
+        bool audioRecvOnly = options.audioRecvOnlyMode;
 
         // Initialize field trials.
         if (fieldTrials == nil) {
@@ -56,6 +57,14 @@
 
         // Initialize logging.
         RTCSetMinDebugLogLevel(loggingSeverity);
+
+        // Configure Webrtc Audio Session to be recvOnly mode
+        if (audioRecvOnly) {
+          RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *webRTCConfig =
+              [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) webRTCConfiguration];
+          webRTCConfig.audioRecvOnlyMode = true;
+          [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) setWebRTCConfiguration:webRTCConfig];
+        }
 
         if (encoderFactory == nil) {
             encoderFactory = [[RTCDefaultVideoEncoderFactory alloc] init];

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -45,7 +45,7 @@
         id<RTCVideoEncoderFactory> encoderFactory = options.videoEncoderFactory;
         NSDictionary *fieldTrials = options.fieldTrials;
         RTCLoggingSeverity loggingSeverity = options.loggingSeverity;
-        bool audioRecvOnly = options.audioRecvOnlyMode;
+        bool audioRecvOnly = options.audioReceiveOnlyMode;
 
         // Initialize field trials.
         if (fieldTrials == nil) {
@@ -62,7 +62,7 @@
         if (audioRecvOnly) {
           RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *webRTCConfig =
               [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) webRTCConfiguration];
-          webRTCConfig.audioRecvOnlyMode = true;
+          webRTCConfig.recvOnlyMode = true;
           [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) setWebRTCConfiguration:webRTCConfig];
         }
 

--- a/ios/RCTWebRTC/WebRTCModuleOptions.h
+++ b/ios/RCTWebRTC/WebRTCModuleOptions.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable) id<RTCAudioDevice> audioDevice;
 @property(nonatomic, strong, nullable) NSDictionary *fieldTrials;
 @property(nonatomic, assign) RTCLoggingSeverity loggingSeverity;
-@property(atomic, assing) bool audioRecvOnlyMode;
+@property(atomic, assign) Boolean audioReceiveOnlyMode;
 
 #pragma mark - This class is a singleton
 

--- a/ios/RCTWebRTC/WebRTCModuleOptions.h
+++ b/ios/RCTWebRTC/WebRTCModuleOptions.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable) id<RTCAudioDevice> audioDevice;
 @property(nonatomic, strong, nullable) NSDictionary *fieldTrials;
 @property(nonatomic, assign) RTCLoggingSeverity loggingSeverity;
+@property(atomic, assing) bool audioRecvOnlyMode;
 
 #pragma mark - This class is a singleton
 

--- a/ios/RCTWebRTC/WebRTCModuleOptions.m
+++ b/ios/RCTWebRTC/WebRTCModuleOptions.m
@@ -22,6 +22,7 @@
         self.videoEncoderFactory = nil;
         self.videoDecoderFactory = nil;
         self.loggingSeverity = RTCLoggingSeverityNone;
+        self.audioRecvOnlyMode = false;
     }
 
     return self;

--- a/ios/RCTWebRTC/WebRTCModuleOptions.m
+++ b/ios/RCTWebRTC/WebRTCModuleOptions.m
@@ -22,7 +22,7 @@
         self.videoEncoderFactory = nil;
         self.videoDecoderFactory = nil;
         self.loggingSeverity = RTCLoggingSeverityNone;
-        self.audioRecvOnlyMode = false;
+        self.audioReceiveOnlyMode = true;
     }
 
     return self;

--- a/react-native-webrtc.podspec
+++ b/react-native-webrtc.podspec
@@ -19,5 +19,9 @@ Pod::Spec.new do |s|
   s.libraries           = 'c', 'sqlite3', 'stdc++'
   s.framework           = 'AudioToolbox','AVFoundation', 'CoreAudio', 'CoreGraphics', 'CoreVideo', 'GLKit', 'VideoToolbox'
   s.dependency          'React-Core'
-  s.dependency          'JitsiWebRTC', '~> 118.0.0'
+
+  # Note: Update to consume local WebRTC.xcframework
+  # To be supplied as a local pod in the RN Application project
+  # TODO: Move the dependency to be consumed from a private pod specs repo instead
+  s.dependency          'WebRTC'
 end


### PR DESCRIPTION
- The boolean will be read when the WebRTCModule has init constructor called
- Thus it must be set in the iOS part of the app (not JS)
- Setting this method will make it so that the AudioUnit is configured as output only
- In order to record app would need to be reloaded